### PR TITLE
Added setup.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+matplotlib
+pytest
+termcolor

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,0 +1,3 @@
+numpy
+numba
+quadpy

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,18 @@
+from setuptools import setup, find_packages
+
+with open("requirements.txt") as f:
+    requirements = f.read().splitlines()
+
+with open("requirements_test.txt") as f:
+    requirements_test = f.read().splitlines()
+
+setup(
+    name="ssqueezepy",
+    version="0.5.0rc1",
+    description="Synchrosqueezing Toolbox ported to Python",
+    install_requires=requirements,
+    tests_require=requirements_test,
+    packages=find_packages(),
+    license="TBD",
+    author="OverLordGoldDragon",
+)


### PR DESCRIPTION
So far the package isn't really pip installable due to lack of a `setup.py`. I thought I'd add something basic to get you started, including properly specifying dependencies.

I guess few people in the Python community actually download releases from GitHub. So I guess you can safe you some time, and simply add a pip + git based installation instruction to the README like:

```
pip install git+https://github.com/OverLordGoldDragon/ssqueezepy
```

I could also help with publishing to PyPI in the long term.