### PR TITLE
Tweak padding scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ viz(x, Tx, Wx)
  4. [Why oscillations in SSQ of mixed sines? Separability visuals](https://dsp.stackexchange.com/a/72239/50076)
  5. [Zero-padding's effect on spectrum](https://dsp.stackexchange.com/a/70498/50076)
 
-**Introductory DSP**: I recommend starting with 3b1b's [Fourier Transform](https://youtu.be/spUNpyF58BY), then proceeding with [DSP Guide](https://www.dspguide.com/CH7.PDF) chapters 7-11.
+**DSP fundamentals**: I recommend starting with 3b1b's [Fourier Transform](https://youtu.be/spUNpyF58BY), then proceeding with [DSP Guide](https://www.dspguide.com/CH7.PDF) chapters 7-11.
 The Discrete Fourier Transform lays the foundation of signal processing with real data. Deeper on DFT coefficients [here](https://dsp.stackexchange.com/a/70395/50076), also [3b1b](https://youtu.be/g8RkArhtCc4).
 
 ## References

--- a/README.md
+++ b/README.md
@@ -82,6 +82,17 @@ Tx, _, Wx, *_ = ssq_cwt(x, 'morlet')
 viz(x, Tx, Wx)
 ```
 
+## Learning resources
+
+ 1. [Continuous Wavelet Transform, & vs STFT](https://ccrma.stanford.edu/~unjung/mylec/WTpart1.html)
+ 2. [Synchrosqueezing's phase transform, intuitively](https://dsp.stackexchange.com/a/72238/50076)
+ 3. [Wavelet time & frequency resolution visuals](https://dsp.stackexchange.com/a/72044/50076)
+ 4. [Why oscillations in SSQ of mixed sines? Separability visuals](https://dsp.stackexchange.com/a/72239/50076)
+ 5. [Zero-padding's effect on spectrum](https://dsp.stackexchange.com/a/70498/50076)
+
+**Introductory DSP**: I recommend starting with 3b1b's [Fourier Transform](https://youtu.be/spUNpyF58BY), then proceeding with [DSP Guide](https://www.dspguide.com/CH7.PDF) chapters 7-11.
+The Discrete Fourier Transform lays the foundation of signal processing with real data. Deeper on DFT coefficients [here](https://dsp.stackexchange.com/a/70395/50076), also [3b1b](https://youtu.be/g8RkArhtCc4).
+
 ## References
 
 `ssqueezepy` was originally ported from MATLAB's [Synchrosqueezing Toolbox](https://github.com/ebrevdo/synchrosqueezing), authored by E. Brevdo and G. Thakur [1]. Synchrosqueezed Wavelet Transform was introduced by I. Daubechies and S. Maes [2], which was followed-up in [3]. Many implementation details draw from [4].

--- a/ssqueezepy/__init__.py
+++ b/ssqueezepy/__init__.py
@@ -27,7 +27,7 @@ SOFTWARE.
 """
 
 
-__version__ = '0.5.0'
+__version__ = '0.5.1'
 __title__ = 'ssqueezepy'
 __author__ = 'OverLordGoldDragon'
 __license__ = __doc__

--- a/ssqueezepy/_ssq_cwt.py
+++ b/ssqueezepy/_ssq_cwt.py
@@ -202,7 +202,7 @@ def ssq_cwt(x, wavelet='morlet', scales='log', nv=None, fs=None, t=None,
         Wx = Wx[:, 4:-4]
         w  = w[:,  4:-4]
         Tx = Tx[:, 4:-4]
-    return Tx, ssq_freqs, Wx, scales, w
+    return Tx, ssq_freqs, Wx, scales, w  # TODO change return order
 
 
 def issq_cwt(Tx, wavelet, cc=None, cw=None):

--- a/ssqueezepy/utils.py
+++ b/ssqueezepy/utils.py
@@ -67,8 +67,8 @@ def p2up(n):
     eps = np.finfo(np.float64).eps  # machine epsilon for float64
     up = 2 ** (1 + np.round(np.log2(n + eps)))
 
-    n1 = np.floor((up - n) / 2)
-    n2 = n1 + n % 2           # if n is odd, right-pad by (n1 + 1), else n2=n1
+    n2 = np.floor((up - n) / 2)
+    n1 = n2 + n % 2           # if n is odd, left-pad by (n2 + 1), else n1=n2
     assert n1 + n + n2 == up  # [left_pad, original, right_pad]
     return int(up), int(n1), int(n2)
 

--- a/ssqueezepy/visuals.py
+++ b/ssqueezepy/visuals.py
@@ -662,7 +662,7 @@ def _ticks(xticks, yticks):
 
 def _maybe_title(title):
     if title is not None:
-        plt.title(str(title), loc='left', weight='bold', fontsize=17)
+        plt.title(str(title), loc='left', weight='bold', fontsize=16)
 
 
 def _scale_plot(fig, ax, show=False, ax_equal=False, w=None, h=None,

--- a/ssqueezepy/visuals.py
+++ b/ssqueezepy/visuals.py
@@ -548,14 +548,8 @@ def imshow(data, title=None, show=1, cmap=None, norm=None, complex=None, abs=0,
     if not ticks:
         plt.xticks([])
         plt.yticks([])
-    if yticks is not None:
-        idxs = np.linspace(0, len(yticks) - 1, 8).astype('int32')
-        yt = ["%.2f" % h for h in yticks[idxs]]
-        plt.yticks(idxs, yt)
-    if xticks is not None:
-        idxs = np.linspace(0, len(xticks) - 1, 8).astype('int32')
-        xt = ["%.2f" % h for h in xticks[idxs]]
-        plt.xticks(idxs, xt)
+    if xticks is not None or yticks is not None:
+        _ticks(xticks, yticks)
     if xlabel is not None:
         plt.xlabel(xlabel, weight='bold', fontsize=15)
     if ylabel is not None:
@@ -566,9 +560,10 @@ def imshow(data, title=None, show=1, cmap=None, norm=None, complex=None, abs=0,
         plt.show()
 
 
-def plot(x, y=None, title=None, show=0, ax_equal=False, complex=0,
+def plot(x, y=None, title=None, show=0, ax_equal=False, complex=0, abs=0,
          c_annot=False, w=None, h=None, dx1=False, xlims=None, ylims=None,
-         vert=False, vlines=None, hlines=None, xlabel=None, ylabel=None, **kw):
+         vert=False, vlines=None, hlines=None, xlabel=None, ylabel=None,
+         xticks=None, yticks=None, **kw):
     if y is None:
         y = x
         x = np.arange(len(x))
@@ -582,6 +577,8 @@ def plot(x, y=None, title=None, show=0, ax_equal=False, complex=0,
             plt.annotate("real", xy=(.93, .95), color='tab:blue', **_kw)
             plt.annotate("imag", xy=(.93, .90), color='tab:orange', **_kw)
     else:
+        if abs:
+            y = np.abs(y)
         plt.plot(x, y, **kw)
     if dx1:
         plt.xticks(np.arange(len(x)))
@@ -590,6 +587,8 @@ def plot(x, y=None, title=None, show=0, ax_equal=False, complex=0,
         vhlines(vlines, kind='v')
     if hlines:
         vhlines(hlines, kind='h')
+    if xticks is not None or yticks is not None:
+        _ticks(xticks, yticks)
 
     _maybe_title(title)
     _scale_plot(plt.gcf(), plt.gca(), show=show, ax_equal=ax_equal, w=w, h=h,
@@ -647,10 +646,23 @@ def _fmt(*nums):
     return [(("%.3e" % n) if (abs(n) > 1e3 or abs(n) < 1e-3) else
              ("%.3f" % n)) for n in nums]
 
+def _ticks(xticks, yticks):
+    def fmt(ticks):
+        return ("%.d" if all(float(h).is_integer() for h in ticks) else
+                "%.2f")
+
+    if yticks is not None:
+        idxs = np.linspace(0, len(yticks) - 1, 8).astype('int32')
+        yt = [fmt(yticks) % h for h in np.asarray(yticks)[idxs]]
+        plt.yticks(idxs, yt)
+    if xticks is not None:
+        idxs = np.linspace(0, len(xticks) - 1, 8).astype('int32')
+        xt = [fmt(xticks) % h for h in np.asarray(xticks)[idxs]]
+        plt.xticks(idxs, xt)
 
 def _maybe_title(title):
     if title is not None:
-        plt.title(str(title), loc='left', weight='bold', fontsize=16)
+        plt.title(str(title), loc='left', weight='bold', fontsize=17)
 
 
 def _scale_plot(fig, ax, show=False, ax_equal=False, w=None, h=None,

--- a/tests/all_test.py
+++ b/tests/all_test.py
@@ -135,7 +135,8 @@ def test_visuals():
     hist(x, show=1, stats=1)
 
     y = x * (1 + 1j)
-    plot(y, complex=1, c_annot=1, vlines=1, ax_equal=1)
+    plot(y, complex=1, c_annot=1, vlines=1, ax_equal=1,
+         xticks=np.arange(len(y)), yticks=y)
 
     scat(x, vlines=1, hlines=1)
     imshow(np.random.randn(4, 4), complex=1)


### PR DESCRIPTION
 - Longer pad from left rather than right to attain perfect sinusoid `endpoint=False`-equivalent post-padding, as [here](https://dsp.stackexchange.com/a/72238/50076)
 - Added few visuals options for `plot`
 - Added learning resources to README
 - Plan to change parameter return order for `ssq_cwt` and `ssqueeze` for v0.6.0