### PR TITLE
Maintenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,16 @@
-### 0.6.2
+### 0.6.2 (1-23-2022): QoL, cleanups, fixes
 
 #### FEATURES
  - `freq_to_scale` & `scale_to_freq`, experimental
- - Optional `nan_checks`
  - Improved auto-`scales`
+ - Optional `nan_checks`
  - Improved default `gamma`
 
 #### BREAKING
  - `ssq_freqs` now correctly maps frequencies to corresponding rows of `Tx` for `ssq_cwt`, no longer requiring `[::-1]`
  - `scales` returned as 1D
+ - `extract_ridges`: `ridge_f` (formerly `fridge`) now returns `scales` rather than `log(scales)`
+ - `extract_ridges`: renamed: `fridge -> ridge_f`, `max_energy -> ridge_e`
 
 #### FIXES
  - False warning for `t` & `fs`
@@ -57,6 +59,7 @@
 
 #### NOTES
  - Undocumented changes; skimming docstrings / source code should suffice for most purposes
+
 
 
 ### 0.6.0 (2-19-2021): Generalized Morse Wavelets, Ridge Extraction, Testing Suite
@@ -116,6 +119,7 @@
  - `tests/` added: `gmw_test.py`, `test_signals_test.py`, `ridge_extraction_test.py`
  - `examples/` added: `extracting_ridges.py`, `scales_selection.py`, `ridge_extract_readme/`: `README.md`, `imgs/*`
  - Created `MANIFEST.in`
+
 
 
 ### 0.5.5 (1-14-2021): STFT & Synchrosqueezed STFT

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,25 @@
 
 #### FEATURES
  - `freq_to_scale` & `scale_to_freq`, experimental
+ - Optional `nan_checks`
+ - Improved auto-`scales`
+ - Improved default `gamma`
+
+#### BREAKING
+ - `ssq_freqs` now correctly maps frequencies to corresponding rows of `Tx` for `ssq_cwt`, no longer requiring `[::-1]`
+ - `scales` returned as 1D
+
+#### FIXES
+ - False warning for `t` & `fs`
+ - Extended scope of `astensor` to `scales`, `ssq_freqs`
+ - `visuals`: improve `xticks` & `yticks` handling
 
 #### MISC
+ - Added citation; README changes; docs changes
  - `experimental`: remove `phase_squeeze`, `phase_transform`
+ - `visuals.imshow`: default `cmap='turbo'`
+ - `visuals`: added `auto_xlims`, `squeeze`
+
 
 
 ### 0.6.1 (3-24-2021): GPU & CPU acceleration; caching

--- a/README.md
+++ b/README.md
@@ -98,8 +98,19 @@ See [Performance guide](https://github.com/OverLordGoldDragon/ssqueezepy/blob/ma
 <img src="https://raw.githubusercontent.com/OverLordGoldDragon/ssqueezepy/master/examples/imgs/morlet_5vs20_tf.png">
 <img src="https://user-images.githubusercontent.com/16495490/107297978-e6338080-6a8d-11eb-8a11-60bfd6e4137d.png">
 
-<hr>
+## How's it work?
 
+In a nutshell, synchrosqueezing exploits _redundancy_ of a time-frequency representation to sparsely localize oscillations, by imposing a _prior_. That is, we _assume_ `x` is well-captured by AM-FM components, e.g. based on our knowledge of the underlying process. We surpass Heisenberg's limitations, but only for a _subset_ of all possible signals.
+
+Convolve with localized kernels
+
+<img src="https://raw.githubusercontent.com/OverLordGoldDragon/StackExchangeAnswers/main/SignalProcessing/Q78512%20-%20Wavelet%20Scattering%20explanation/cwt.gif" width="650">
+
+compute phase transform, then combine oscillations with a shared rate
+
+<img src="https://user-images.githubusercontent.com/16495490/150680428-4a651934-85c6-45e8-8a19-c9b4165e5381.png" width="700">
+
+<hr>
 
 ## Minimal example
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ See [Performance guide](https://github.com/OverLordGoldDragon/ssqueezepy/blob/ma
 
 In a nutshell, synchrosqueezing exploits _redundancy_ of a time-frequency representation to sparsely localize oscillations, by imposing a _prior_. That is, we _assume_ `x` is well-captured by AM-FM components, e.g. based on our knowledge of the underlying process. We surpass Heisenberg's limitations, but only for a _subset_ of all possible signals.
 
-Convolve with localized kernels
+Convolve with localized, analytic kernels
 
 <img src="https://raw.githubusercontent.com/OverLordGoldDragon/StackExchangeAnswers/main/SignalProcessing/Q78512%20-%20Wavelet%20Scattering%20explanation/cwt.gif" width="650">
 

--- a/examples/extracting_ridges.py
+++ b/examples/extracting_ridges.py
@@ -17,10 +17,6 @@ def viz(x, Tf, ridge_idxs, yticks=None, ssq=False, transform='cwt', show_x=True)
         plot(x, title="x(t)", show=1,
              xlabel="Time [samples]", ylabel="Signal Amplitude [A.U.]")
 
-    if transform == 'cwt' and not ssq:
-        Tf = np.flipud(Tf)
-        ridge_idxs = len(Tf) - ridge_idxs
-
     ylabel = ("Frequency scales [1/Hz]" if (transform == 'cwt' and not ssq) else
               "Frequencies [Hz]")
     title = "abs({}{}) w/ ridge_idxs".format("SSQ_" if ssq else "",
@@ -28,7 +24,7 @@ def viz(x, Tf, ridge_idxs, yticks=None, ssq=False, transform='cwt', show_x=True)
 
     ikw = dict(abs=1, cmap='turbo', yticks=yticks, title=title)
     pkw = dict(linestyle='--', color='k', xlabel="Time [samples]", ylabel=ylabel,
-               xlims=(0, Tf.shape[1]), ylims=(0, len(Tf)))
+               xlims=(0, Tf.shape[1]))
 
     imshow(Tf, **ikw, show=0)
     plot(ridge_idxs, **pkw, show=1)
@@ -38,9 +34,10 @@ def tf_transforms(x, t, wavelet='morlet', window=None, padtype='wrap',
                   penalty=.5, n_ridges=2, cwt_bw=15, stft_bw=15,
                   ssq_cwt_bw=4, ssq_stft_bw=4):
     kw_cwt  = dict(t=t, padtype=padtype)
-    kw_stft = dict(fs=1/(t[1] - t[0]), padtype=padtype)
+    kw_stft = dict(fs=1/(t[1] - t[0]), padtype=padtype, flipud=1)
     Twx, Wx, ssq_freqs_c, scales, *_ = ssq_cwt(x,  wavelet, **kw_cwt)
     Tsx, Sx, ssq_freqs_s, Sfs, *_    = ssq_stft(x, window,  **kw_stft)
+    Sx, Sfs = Sx[::-1], Sfs[::-1]
 
     ckw = dict(penalty=penalty, n_ridges=n_ridges, transform='cwt')
     skw = dict(penalty=penalty, n_ridges=n_ridges, transform='stft')

--- a/examples/se_ans0.py
+++ b/examples/se_ans0.py
@@ -25,14 +25,15 @@ x = cos_f([f], N=N)
 Wx, scales, *_ = cwt(x, wavelet, fs=N)
 
 #%%# Show, print max row
-imshow(Wx, abs=1, yticks=scales, title="f=%d, N=%d" % (f, N), show=1)
+imshow(Wx, abs=1, yticks=scales, title="f=%d, N=%d" % (f, N), show=1,
+       cmap='bone')
 mxidx = np.where(np.abs(Wx) == np.abs(Wx).max())[0][0]
 print("Max row idx:", mxidx, flush=True)
 
 #%%# Plot aroundI max row
 idxs = slice(mxidx - 30, mxidx + 20)
 Wxz = Wx[idxs]
-imshow(Wxz, abs=1, title="abs(CWT), zoomed", show=0)
+imshow(Wxz, abs=1, title="abs(CWT), zoomed", show=0, cmap='bone')
 plt.axhline(30, color='r')
 plt.show()
 
@@ -78,7 +79,7 @@ wavelet = ('morlet', {'mu': 5})
 Tx, *_ = ssq_cwt(s, wavelet, t=t)
 #%%# 'cheat' a little; could use boundary wavelets instead (not implemented)
 aTxz = np.abs(Tx)[:, len(t) // 8:]
-imshow(aTxz, abs=1, title="abs(SSWT(s(t)))", show=1)
+imshow(aTxz, abs=1, title="abs(SSWT(s(t)))", show=1, cmap='bone')
 #%%
 mxidx = np.where(np.abs(aTxz) == np.abs(aTxz).max())[0][0]
 plot(aTxz[mxidx], title="max row of abs(SSWT(s(t)))", show=1)

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright © OverLordGoldDragon
+# Copyright © 2020 John Muradeli
 # Licensed under the terms of the MIT License
 # (see ssqueezepy/__init__.py for details)
 
@@ -48,8 +48,8 @@ setup(
     packages=find_packages(exclude=['tests', 'examples']),
     url="https://github.com/OverLordGoldDragon/ssqueezepy",
     license="MIT",
-    author="OverLordGoldDragon",
-    author_email="16495490+OverLordGoldDragon@users.noreply.github.com",
+    author="John Muradeli",
+    author_email="john.muradeli@gmail.com",
     description=("Synchrosqueezing, wavelet transforms, and "
                  "time-frequency analysis in Python"),
     long_description=read_file('README.md'),

--- a/ssqueezepy/__init__.py
+++ b/ssqueezepy/__init__.py
@@ -5,7 +5,7 @@ MIT License
 
 Some ssqueezepy source files under other terms (see NOTICE.txt).
 
-Copyright (c) 2020 OverLordGoldDragon
+Copyright (c) 2020 John Muradeli
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -27,9 +27,9 @@ SOFTWARE.
 """
 
 
-__version__ = '0.6.1'
+__version__ = '0.6.2'
 __title__ = 'ssqueezepy'
-__author__ = 'OverLordGoldDragon'
+__author__ = 'John Muradeli'
 __license__ = __doc__
 __project_url__ = 'https://github.com/OverLordGoldDragon/ssqueezepy'
 

--- a/ssqueezepy/_ssq_stft.py
+++ b/ssqueezepy/_ssq_stft.py
@@ -77,7 +77,7 @@ def ssq_stft(x, window=None, n_fft=None, win_len=None, hop_len=1, fs=None, t=Non
     _check_ssqueezing_args(squeezing)
     # assert ssq_freqs, if array, is linear
     if (isinstance(ssq_freqs, np.ndarray) and
-            infer_scaletype(ssq_freqs) != 'linear'):
+            infer_scaletype(ssq_freqs)[0] != 'linear'):
         raise ValueError("`ssq_freqs` must be linearly distributed "
                          "for `ssq_stft`")
 
@@ -118,8 +118,9 @@ def ssq_stft(x, window=None, n_fft=None, win_len=None, hop_len=1, fs=None, t=Non
                              maprange='maximal', transform='stft')
     # return
     if not astensor and S.is_tensor(Tx):
-        Tx, Sx, w, dSx = [g.cpu().numpy() if S.is_tensor(g) else g
-                          for g in (Tx, Sx, w, dSx)]
+        Tx, Sx, ssq_freqs, Sfs, w, dSx = [
+            g.cpu().numpy() if S.is_tensor(g) else g
+            for g in (Tx, Sx, ssq_freqs, Sfs, w, dSx)]
 
     if get_w and get_dWx:
         return Tx, Sx, ssq_freqs, Sfs, w, dSx

--- a/ssqueezepy/ridge_extraction.py
+++ b/ssqueezepy/ridge_extraction.py
@@ -50,7 +50,9 @@ def extract_ridges(Tf, scales, penalty=2., n_ridges=1, bw=15, transform='cwt',
         ridge_idxs: np.ndarray
             Indices for maximum frequency ridge(s).
         fridge: np.ndarray
-            Frequencies tracking maximum frequency ridge(s).
+            Quantities tracking maximum frequency ridges:
+                - STFT: frequencies
+                - CWT: scales
         max_energy: np.ndarray [n_timeshifts x n_ridges]
             Energy maxima vectors along time axis.
 
@@ -113,9 +115,9 @@ def extract_ridges(Tf, scales, penalty=2., n_ridges=1, bw=15, transform='cwt',
     scales, eps, penalty = [np.asarray(x, dtype=dtype)
                             for x in (scales, eps, penalty)]
 
+    scales_orig = scales.copy()
     scales = (np.log(scales) if transform == 'cwt' else
-              scales)
-    scales = scales.squeeze()
+              scales).squeeze()
     energy = np.abs(Tf)**2
     n_timeshifts = Tf.shape[1]
 
@@ -134,7 +136,7 @@ def extract_ridges(Tf, scales, penalty=2., n_ridges=1, bw=15, transform='cwt',
                                                 penalty_matrix, eps)
         if get_params:
             max_energy[:, i] = energy[ridge_idxs[:, i], range(n_timeshifts)]
-            fridge[:, i] = scales[ridge_idxs[:, i]]
+            fridge[:, i] = scales_orig[ridge_idxs[:, i]]
 
         for time_idx in range(n_timeshifts):
             ridx = ridge_idxs[time_idx, i]

--- a/ssqueezepy/ssqueezing.py
+++ b/ssqueezepy/ssqueezing.py
@@ -208,6 +208,12 @@ def ssqueeze(Wx, w=None, ssq_freqs=None, scales=None, Sfs=None, fs=None, t=None,
         for _Tx, _w, _Wx, _dWx in zip(Tx, w, Wx, dWx):
             _ssqueeze(_Tx, _w, _Wx, _dWx, *args)
 
+    # `scales` go high -> low
+    if transform == 'cwt' and not flipud:
+        ssq_freqs = ssq_freqs[::-1]
+    elif flipud:
+        ssq_freqs = ssq_freqs[::-1]
+
     return Tx, ssq_freqs
 
 

--- a/ssqueezepy/visuals.py
+++ b/ssqueezepy/visuals.py
@@ -635,6 +635,16 @@ def viz_gmw_orders(N=1024, n_orders=3, scale=5, gamma=3, beta=60,
 def imshow(data, title=None, show=1, cmap=None, norm=None, complex=None, abs=0,
            w=None, h=None, ridge=0, ticks=1, borders=1, aspect='auto', ax=None,
            fig=None, yticks=None, xticks=None, xlabel=None, ylabel=None, **kw):
+    """
+    norm: color norm, tuple of (vmin, vmax)
+    abs: take abs(data) before plotting
+    ticks: False to not plot x & y ticks
+    borders: False to not display plot borders
+    w, h: rescale width & height
+    kw: passed to `plt.imshow()`
+
+    others
+    """
     # axes
     if (ax or fig) and complex:
         NOTE("`ax` and `fig` ignored if `complex`")
@@ -687,7 +697,7 @@ def imshow(data, title=None, show=1, cmap=None, norm=None, complex=None, abs=0,
         ax.set_xticks([])
         ax.set_yticks([])
     if xticks is not None or yticks is not None:
-        _ticks(xticks, yticks)
+        _ticks(xticks, yticks, ax)
     if not borders:
         for spine in ax.spines:
             ax.spines[spine].set_visible(False)
@@ -706,6 +716,16 @@ def plot(x, y=None, title=None, show=0, ax_equal=False, complex=0, abs=0,
          vert=False, vlines=None, hlines=None, xlabel=None, ylabel=None,
          xticks=None, yticks=None, ax=None, fig=None, ticks=True, squeeze=True,
          auto_xlims=True, **kw):
+    """
+    norm: color norm, tuple of (vmin, vmax)
+    abs: take abs(data) before plotting
+    complex: plot `x.real` & `x.imag`
+    ticks: False to not plot x & y ticks
+    w, h: rescale width & height
+    kw: passed to `plt.imshow()`
+
+    others
+    """
     ax  = ax  or plt.gca()
     fig = fig or plt.gcf()
 
@@ -752,9 +772,9 @@ def plot(x, y=None, title=None, show=0, ax_equal=False, complex=0, abs=0,
     if not ticks[1]:
         ax.set_yticks([])
     if xticks is not None or yticks is not None:
-        _ticks(xticks, yticks)
+        _ticks(xticks, yticks, ax)
     if xticks is not None or yticks is not None:
-        _ticks(xticks, yticks)
+        _ticks(xticks, yticks, ax)
 
     _maybe_title(title, ax=ax)
     _scale_plot(fig, ax, show=show, ax_equal=ax_equal, w=w, h=h,
@@ -906,19 +926,27 @@ def _fmt(*nums):
     return [(("%.3e" % n) if (abs(n) > 1e3 or abs(n) < 1e-3) else
              ("%.3f" % n)) for n in nums]
 
-def _ticks(xticks, yticks):
+def _ticks(xticks, yticks, ax):
     def fmt(ticks):
         return ("%.d" if all(float(h).is_integer() for h in ticks) else
                 "%.2f")
 
     if yticks is not None:
-        idxs = np.linspace(0, len(yticks) - 1, 8).astype('int32')
-        yt = [fmt(yticks) % h for h in np.asarray(yticks)[idxs]]
-        plt.yticks(idxs, yt)
+        if not hasattr(yticks, '__len__') and not yticks:
+            ax.set_yticks([])
+        else:
+            idxs = np.linspace(0, len(yticks) - 1, 8).astype('int32')
+            yt = [fmt(yticks) % h for h in np.asarray(yticks)[idxs]]
+            ax.set_yticks(idxs)
+            ax.set_yticklabels(yt)
     if xticks is not None:
-        idxs = np.linspace(0, len(xticks) - 1, 8).astype('int32')
-        xt = [fmt(xticks) % h for h in np.asarray(xticks)[idxs]]
-        plt.xticks(idxs, xt)
+        if not hasattr(xticks, '__len__') and not xticks:
+            ax.set_xticks([])
+        else:
+            idxs = np.linspace(0, len(xticks) - 1, 8).astype('int32')
+            xt = [fmt(xticks) % h for h in np.asarray(xticks)[idxs]]
+            ax.set_xticks(idxs)
+            ax.set_xticklabels(xt)
 
 def _maybe_title(title, ax=None):
     if title is None:


### PR DESCRIPTION
**FEATURES**

 1. Optional `nan_checks`


**BREAKING**

 1. `ssq_freqs` now correctly maps frequencies to corresponding rows of `Tx` for `ssq_cwt`, no longer requiring `[::-1]`
 2. `extract_ridges`: `ridge_f` (formerly `fridge`) now returns `scales` rather than `log(scales)`
 3. `extract_ridges`: renamed: `fridge -> ridge_f`, `max_energy -> ridge_e`

**FIXES**

 1. False warning for `t` & `fs`
 2. Extended scope of `astensor` to `scales`, `ssq_freqs`
 3. `visuals`: improve `xticks` & `yticks` handling
 4. Misc

**MISC**

 1. Added `How's it work?` to README
