### PR TITLE
Librosa broke tests

### DIFF
--- a/ssqueezepy/algos.py
+++ b/ssqueezepy/algos.py
@@ -68,10 +68,10 @@ def _process_ssq_params(Wx, w_or_dWx, ssq_freqs, const, logscale, flipud, out,
                  (const.size if isinstance(const, np.ndarray) else 1))
     if len_const != len(Wx):
         if gpu:
-            const_arr = torch.tensor(len(Wx) * [const], dtype=Wx.dtype,
-                                     device=Wx.device)
+            const_arr = torch.full((len(Wx),), fill_value=const,
+                                   device=Wx.device, dtype=Wx.dtype)
         else:
-            const_arr = np.array(len(Wx) * [const])
+            const_arr = np.full(len(Wx), const, dtype=Wx.dtype)
     elif gpu and isinstance(const, np.ndarray):
         const_arr = torch.as_tensor(const, dtype=Wx.dtype, device=Wx.device)
     else:

--- a/ssqueezepy/ssqueezing.py
+++ b/ssqueezepy/ssqueezing.py
@@ -209,10 +209,12 @@ def ssqueeze(Wx, w=None, ssq_freqs=None, scales=None, Sfs=None, fs=None, t=None,
             _ssqueeze(_Tx, _w, _Wx, _dWx, *args)
 
     # `scales` go high -> low
-    if transform == 'cwt' and not flipud:
-        ssq_freqs = ssq_freqs[::-1]
-    elif flipud:
-        ssq_freqs = ssq_freqs[::-1]
+    if (transform == 'cwt' and not flipud) or flipud:
+        if not isinstance(ssq_freqs, np.ndarray):
+            import torch
+            ssq_freqs = torch.flip(ssq_freqs, (0,))
+        else:
+            ssq_freqs = ssq_freqs[::-1]
 
     return Tx, ssq_freqs
 

--- a/ssqueezepy/visuals.py
+++ b/ssqueezepy/visuals.py
@@ -891,12 +891,24 @@ def plotscat(*args, **kw):
         plt.show()
 
 
-def hist(x, bins=500, title=None, show=0, stats=0):
+def hist(x, bins=500, title=None, show=0, stats=0, ax=None, fig=None,
+         w=1, h=1, xlims=None, ylims=None, xlabel=None, ylabel=None):
+    """Histogram. `stats=True` to print mean, std, min, max of `x`."""
+    def _fmt(*nums):
+        return [(("%.3e" % n) if (abs(n) > 1e3 or abs(n) < 1e-3) else
+                 ("%.3f" % n)) for n in nums]
+
+    ax  = ax  or plt.gca()
+    fig = fig or plt.gcf()
+
     x = np.asarray(x)
-    _ = plt.hist(x.ravel(), bins=bins)
-    _maybe_title(title)
+    _ = ax.hist(x.ravel(), bins=bins)
+    _maybe_title(title, ax=ax)
+    _scale_plot(fig, ax, show=show, w=w, h=h, xlims=xlims, ylims=ylims,
+                xlabel=xlabel, ylabel=ylabel)
     if show:
         plt.show()
+
     if stats:
         mu, std, mn, mx = (x.mean(), x.std(), x.min(), x.max())
         print("(mean, std, min, max) = ({}, {}, {}, {})".format(

--- a/tests/reconstruction_test.py
+++ b/tests/reconstruction_test.py
@@ -222,7 +222,7 @@ def test_stft_vs_librosa():
              Sx  = stft( x, n_fft=n_fft, hop_len=hop_len,    win_len=win_len,
                          window='hann', modulated=False, dtype='float64')
              lSx = lstft(x, n_fft=n_fft, hop_length=hop_len, win_length=win_len,
-                         window='hann')
+                         window='hann', pad_mode='reflect')
 
              if n_fft % 2 == 0:
                  if hop_len == 1:


### PR DESCRIPTION
 - librosa defaults to zero padding, which broke `reconstruction_test`
 - fix flipping `ssq_freqs` in torch
 - slight performance boost in `_process_ssq_params`
 - extended `visuals.hist`