### PR TITLE
Fix cumulant

### DIFF
--- a/ssqueezepy/_gmw.py
+++ b/ssqueezepy/_gmw.py
@@ -738,7 +738,7 @@ def _moments_to_cumulants(moments):
 
     for n in range(1, len(moments)):
         coeff = 0
-        for k in range(1, n - 1):
+        for k in range(1, n):
             coeff += nCk(n - 1, k - 1
                          ) * cumulants[k] * (moments[n - k] / moments[0])
         cumulants[n] = (moments[n] / moments[0]) - coeff


### PR DESCRIPTION
I could be wrong, but based on eq. 88 in "Higher-Order Properties of Analytic Wavelets" the sum here should be from 1 to n - 1, which is equivalent to `range(1, n)` in Python. With this change the results match those of eqs. 85-87 in the paper.